### PR TITLE
Added Boogie repo as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "boogie"]
+	path = boogie
+	url = https://github.com/boogie-org/boogie.git

--- a/README.md
+++ b/README.md
@@ -3,7 +3,16 @@
 Corral is a solver for the reachability modulo theories problem. Learn more here: http://research.microsoft.com/en-us/projects/verifierq
 
 ## Dependency on Boogie
-Corral has a dependency on Boogie (https://github.com/boogie-org/boogie). Download Boogie sources with the revision number that is mentioned in ``references\BoogieRev.txt``.
+Corral has a dependency on [Boogie](https://github.com/boogie-org/boogie), which is provided as a git submodule. To download the specific revision of Boogie that Corral depends on:
+
+```
+cd ${CORRAL_DIR}
+git submodule init
+git submodule update
+cd boogie
+```
+
+Then follow the [Boogie](https://github.com/boogie-org/boogie#building) building instructions.
 
 ## Building and running Corral on Windows
 

--- a/references/BoogieRev.txt
+++ b/references/BoogieRev.txt
@@ -1,2 +1,0 @@
-Changeset: ae29deff82ad873a3dd541cb2d74d362d26f94c2
-Date: 2016-04-15 23:30:34


### PR DESCRIPTION
I added the Boogie repo as a git submodule. I updated the README instructions on how to download it. Note that the Boogie submodule is pointing to a specific revision of Boogie (which is the one Corral depends, thus we should not need the BoogieRev.txt file anymore, which I removed!). To update the Boogie submodule to another revision, simply checkout the revision you want, and then make a commit in the Corral repo. This should hopefully make the building process of Corral slightly easier/faster for the end-user.