### PR TITLE
Replace ListEnumertor by Enumerator.  The idea is to use the same nam…

### DIFF
--- a/AddOns/AngelicVerifierNull/test/c#/CollectionStubs.cs
+++ b/AddOns/AngelicVerifierNull/test/c#/CollectionStubs.cs
@@ -41,10 +41,10 @@ namespace System.Collections.Generic
 {
     public abstract class List<T> : IEnumerable<T>
     {
-	struct ListEnumerator : IEnumerator<T> {
+	struct Enumerator : IEnumerator<T> {
 	      List<T> parent;
 	      int iter;
-	      public ListEnumerator(List<T> l) { 
+	      public Enumerator(List<T> l) { 
 	          parent = l; 
 		  iter = -1; 
 	      }
@@ -59,7 +59,7 @@ namespace System.Collections.Generic
 	}
 
         private List(bool dontCallMe) { }
-        public IEnumerator<T> GetEnumerator() { return new ListEnumerator(this); }
+        public IEnumerator<T> GetEnumerator() { return new Enumerator(this); }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return this.GetEnumerator(); }
 	public abstract T this[int index] { get; set; }
 	public abstract int Count { get; }

--- a/AddOns/AngelicVerifierNull/test/c#/Stubs.cs
+++ b/AddOns/AngelicVerifierNull/test/c#/Stubs.cs
@@ -260,10 +260,10 @@ namespace System.Collections.Generic
 {
     public abstract class List<T> : IEnumerable<T>
     {
-	struct ListEnumerator : IEnumerator<T> {
+	struct Enumerator : IEnumerator<T> {
 	      List<T> parent;
 	      int iter;
-	      public ListEnumerator(List<T> l) { 
+	      public Enumerator(List<T> l) {
 	          parent = l; 
 		  iter = -1; 
 	      }
@@ -278,7 +278,7 @@ namespace System.Collections.Generic
 	}
 
         private List(bool dontCallMe) { }
-        public IEnumerator<T> GetEnumerator() { return new ListEnumerator(this); }
+        public IEnumerator<T> GetEnumerator() { return new Enumerator(this); }
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return this.GetEnumerator(); }
 	public abstract T this[int index] { get; set; }
 	public abstract int Count { get; }


### PR DESCRIPTION
Replace ListEnumertor by Enumerator in CollectionsStub.cs
The idea is to use the same named used in mscorlib and also make it consistent with the HashSet stub.
@shuvendu-lahiri  @akashlal 