### PR TITLE
Fixes dealing with bopt Boogie options

### DIFF
--- a/source/Configs.cs
+++ b/source/Configs.cs
@@ -707,7 +707,7 @@ namespace cba
             }
             else if (flag.StartsWith("/bopt:"))
             {
-                boogieOpts += " \"/" + flag.Substring("/bopt:".Length) + "\" ";
+                boogieOpts += " \"-" + flag.Substring("/bopt:".Length) + "\" ";
             }
             else if (flag == "/printBoogieExt")
             {

--- a/source/Util/BoogieUtil.cs
+++ b/source/Util/BoogieUtil.cs
@@ -42,7 +42,8 @@ namespace cba.Util
                     args.Add(quotes[i]);
             }
 
-            CommandLineOptions.Clo.Parse(args.ToArray());
+            if (!CommandLineOptions.Clo.Parse(args.ToArray()))
+                return true;
 
             // No Max: avoids theorem prover restarts
             CommandLineOptions.Clo.MaxProverMemory = 0;


### PR DESCRIPTION
First, it prefixes Boogie options passed with bopt with `-` instead
of `/`. This should have the same effect, and yet it avoids confusion
with path delimiter on Linux.
Second, it makes sure that Corral exits if Boogie cannot parse
an argument.

Closes #63