### PR TITLE
Prop instrumentation match fix for Ref type 

### DIFF
--- a/AddOns/AngelicVerifierNull/test/propinst-regressions/Answer
+++ b/AddOns/AngelicVerifierNull/test/propinst-regressions/Answer
@@ -48,3 +48,8 @@
 [TAG: AV_OUTPUT] ----- Analyzing null0_pinst_hinst.bpl ------
 [TAG: AV_OUTPUT] ANGELIC_VERIFIER_WARNING: Failing traces {Trace0 }
 [TAG: AV_OUTPUT] ANGELIC_VERIFIER_WARNING: Assertion failed in proc foo with expr !(ax == NULL)
+
+-------------------- rodrigo_refnull.bpl --------------------
+[TAG: AV_OUTPUT] ----- Analyzing rodrigo_refnull_pinst_hinst.bpl ------
+[TAG: AV_OUTPUT] ANGELIC_VERIFIER_WARNING: Failing traces {Trace0 }
+[TAG: AV_OUTPUT] ANGELIC_VERIFIER_WARNING: Assertion failed in proc Foo with expr r != null

--- a/AddOns/AngelicVerifierNull/test/propinst-regressions/rodrigo_refnull.bpl
+++ b/AddOns/AngelicVerifierNull/test/propinst-regressions/rodrigo_refnull.bpl
@@ -1,0 +1,9 @@
+type Ref;
+
+const unique null : Ref;
+var r: Ref;
+
+procedure Foo() {
+  r := null;
+  assume {:nonnull} r != null;
+}

--- a/AddOns/AngelicVerifierNull/test/propinst-regressions/runtest.bat
+++ b/AddOns/AngelicVerifierNull/test/propinst-regressions/runtest.bat
@@ -18,6 +18,7 @@ call:add irql0.bpl ..\..\..\PropInst\PropInst\ExampleProperties\checkIrql-razzle
 call:add irql1.bpl ..\..\..\PropInst\PropInst\ExampleProperties\checkIrql-razzle.avp
 call:add irql2.bpl ..\..\..\PropInst\PropInst\ExampleProperties\checkIrql-razzle.avp
 call:add null0.bpl ..\..\..\PropInst\PropInst\ExampleProperties\nullcheck-razzle.avp
+call:add rodrigo_refnull.bpl ..\..\..\PropInst\PropInst\ExampleProperties\nullcheck-csharp.avp
 
 REM for %%f in (eeSlice3.bpl) do (
 set i=0

--- a/AddOns/PropInst/PropInst/ExampleProperties/nullcheck-csharp.avp
+++ b/AddOns/PropInst/PropInst/ExampleProperties/nullcheck-csharp.avp
@@ -1,0 +1,21 @@
+GlobalDeclarations
+{
+function {:inline} {:aliasingQuery} {:mkUniqueFn} aliasQ(p:Ref, q:Ref) returns (bool) { p == q }
+}
+
+
+TemplateVariables
+{
+var p : Ref;
+}
+
+
+//Check every dereference
+CmdRule
+{
+  assume {:nonnull} p != null;
+}
+-->
+{
+  assert p != null;
+}

--- a/source/Util/Visitor.cs
+++ b/source/Util/Visitor.cs
@@ -1294,7 +1294,7 @@ namespace cba.Util
                 var nodeFunc = ((FunctionCall)node.Fun).Func;
                 for (var i = 0; i < tcFunc.InParams.Count; i++)
                 {
-                    if (!Equals(tcFunc.InParams[i].TypedIdent.Type, nodeFunc.InParams[i].TypedIdent.Type))
+                    if (!Equals(tcFunc.InParams[i].TypedIdent.Type.ToString(), nodeFunc.InParams[i].TypedIdent.Type.ToString()))
                     {
                         Matches = false;
                         return base.VisitNAryExpr(node);
@@ -1355,7 +1355,7 @@ namespace cba.Util
 
             if (idexToConsume.Decl != null)
             {
-                if (Equals(node.Decl.TypedIdent.Type, idexToConsume.Decl.TypedIdent.Type)
+                if (Equals(node.Decl.TypedIdent.Type.ToString(), idexToConsume.Decl.TypedIdent.Type.ToString())
                     && AreAttributesASubset(idexToConsume.Decl.Attributes, node.Decl.Attributes))
                 {
                     Substitution.Add(idexToConsume.Decl, node);


### PR DESCRIPTION
Fix for issue #67  identified by Rodrigo for TinyBCT.

Corral regressions in test\{perl check.pl} works
AV regressions in AddOns\AngelicVerifierNull\test\{avn-regressions, propinst-regressions} pass with the added test, that would have failed before. 