### PR TITLE
Remove references to the AIFramework project

### DIFF
--- a/AddOns/BctMemInst/BctMemInst.sln
+++ b/AddOns/BctMemInst/BctMemInst.sln
@@ -9,8 +9,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "boogie", "boogie", "{EEB813
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AbsInt", "..\..\boogie\Source\AbsInt\AbsInt.csproj", "{0EFA3E43-690B-48DC-A72C-384A3EA7F31F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AIFramework", "..\..\boogie\Source\AIFramework\AIFramework.csproj", "{39B0658D-C955-41C5-9A43-48C97A1EF5FD}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Basetypes", "..\..\boogie\Source\Basetypes\Basetypes.csproj", "{43DFAD18-3E35-4558-9BE2-CAFF6B5BA8A0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeContractsExtender", "..\..\boogie\Source\CodeContractsExtender\CodeContractsExtender.csproj", "{ACCC0156-0921-43ED-8F67-AD8BDC8CDE31}"

--- a/AddOns/BctMemInst/BctMemInst/BctMemInst.csproj
+++ b/AddOns/BctMemInst/BctMemInst/BctMemInst.csproj
@@ -54,10 +54,6 @@
       <Project>{0efa3e43-690b-48dc-a72c-384a3ea7f31f}</Project>
       <Name>AbsInt</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\boogie\Source\AIFramework\AIFramework.csproj">
-      <Project>{39b0658d-c955-41c5-9a43-48c97a1ef5fd}</Project>
-      <Name>AIFramework</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\boogie\Source\Basetypes\Basetypes.csproj">
       <Project>{43dfad18-3e35-4558-9be2-caff6b5ba8a0}</Project>
       <Name>Basetypes</Name>


### PR DESCRIPTION
AIFramework was not used for a long time in Boogie and now removed from the codebase.