### PR TITLE
Remove dead Boogie options

### DIFF
--- a/source/CoreLib/VerificationPasses.cs
+++ b/source/CoreLib/VerificationPasses.cs
@@ -1158,7 +1158,6 @@ namespace cba
                 Debug.Assert(onlyEnsures());
                 // Turn on summary computation in Boogie
                 Debug.Assert(CommandLineOptions.Clo.StratifiedInlining > 0);
-                CommandLineOptions.Clo.StratifiedInliningOption = 1;
             }
 
             // Insert summaries
@@ -1694,14 +1693,7 @@ namespace cba
 
         public override ErrorTrace mapBackTrace(ErrorTrace trace)
         {
-            var ret = trace;
-            if(ExtractLoops) ret = elPass.mapBackTrace(trace);
-
-            if (!runHoudini)
-            {
-                CommandLineOptions.Clo.StratifiedInliningOption = 0;
-            }
-            return ret;
+            return ExtractLoops ? elPass.mapBackTrace(trace) : trace;
         }
     }
 

--- a/source/Util/BoogieUtil.cs
+++ b/source/Util/BoogieUtil.cs
@@ -45,9 +45,6 @@ namespace cba.Util
             if (!CommandLineOptions.Clo.Parse(args.ToArray()))
                 return true;
 
-            // No Max: avoids theorem prover restarts
-            CommandLineOptions.Clo.MaxProverMemory = 0;
-
             return false;
         }
 


### PR DESCRIPTION
`StratifiedInliningOption` and `MaxProverMemory` are dead in Boogie (and will be removed if no reason for keeping them pops up).