### PR TITLE
Allow Corral to be built for .NET 6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Checkout Corral
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: Checkout Corral
         uses: actions/checkout@v2
         with:

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Target framework and package configuration -->
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Corral</Authors>
     <RepositoryUrl>https://github.com/boogie-org/corral</RepositoryUrl>


### PR DESCRIPTION
This adds dotnet 6 as a build target for Corral. This is needed because the dotnet 5.0 framework target is architecture unaware on M1 Macs and this leads to missing runtime libraries for the target architecture. This enables Corral to run in dotnet 6 on that platform.